### PR TITLE
Gets version for jupyter notebook

### DIFF
--- a/bin/itypescript.js
+++ b/bin/itypescript.js
@@ -300,7 +300,7 @@ var Main = /** @class */ (function () {
      * @param callback
      */
     Main.setJupyterInfoAsync = function (callback) {
-        child_process_1.exec("jupyter --version", function (error, stdout) {
+        child_process_1.exec("jupyter notebook --version", function (error, stdout) {
             if (error) {
                 // If error, try with IPython notebook
                 Main.frontIdentificationError = error;

--- a/bin/itypescript.ts
+++ b/bin/itypescript.ts
@@ -361,7 +361,7 @@ class Main {
      * @param callback
      */
     static setJupyterInfoAsync(callback?: () => void) {
-        exec("jupyter --version", function (error, stdout) {
+        exec("jupyter notebook --version", function (error, stdout) {
             if (error) {
                 // If error, try with IPython notebook
                 Main.frontIdentificationError = error;


### PR DESCRIPTION
`jupyter --version` returns an output such as:
```
jupyter core     : 4.5.0
jupyter-notebook : 5.7.8
qtconsole        : 4.5.1
...
```
Running `jupyter notebook --version` gets only the notebook version.
Have not tested on other machines other than my local setup... :roll_eyes: 